### PR TITLE
Add test button.rs

### DIFF
--- a/material-yew/Cargo.toml
+++ b/material-yew/Cargo.toml
@@ -29,6 +29,9 @@ features = [
     "HtmlElement"
 ]
 
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [features]
 button = []
 circular-progress = []
@@ -80,7 +83,9 @@ full = [
     "select",
     "menu",
 ]
-default = []
+default = [
+    "button",
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/material-yew/tests/button.rs
+++ b/material-yew/tests/button.rs
@@ -1,0 +1,28 @@
+#![cfg(target_arch = "wasm32")]
+
+use material_yew::MatButton;
+use wasm_bindgen_test::*;
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+use yew::prelude::*;
+
+#[wasm_bindgen_test]
+fn test_button() {
+
+    fn type_of<T>(_: T) -> String {
+        let type_name = std::any::type_name::<T>();
+        return type_name.to_string();
+    }
+
+    let matbutton: Html =  html! {
+        <>
+          <MatButton label="test" />
+        </>
+        };
+
+    let minimum_html: Html = html! {
+        <>
+        </>
+    };
+
+    assert_eq!(type_of(&matbutton), type_of(&minimum_html));
+}


### PR DESCRIPTION
I added a test to see if button.rs can be converted as html.
If this PR is OK, I will write tests for all elements.
I will also try to make the test run automatically with GitHubActions
You can test by running 
```wasm-pack test --chrome --headless```
 in material-yew/material-yew
Thanks in advance.